### PR TITLE
split EnvStringSlice on ,

### DIFF
--- a/deploy/pkg/deployer/config.go
+++ b/deploy/pkg/deployer/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -71,7 +72,7 @@ func getEnv(key, fallback string) string {
 
 func getEnvStringSlice(key string) []string {
 	if value, ok := os.LookupEnv(key); ok {
-		return []string{value}
+		return strings.Split(value, ",")
 	}
 
 	return []string{}


### PR DESCRIPTION
Currently, attempting to use the deploy cli with the env var `VAR` set to a comma separated list like: `foo=bar,baz=foo` results in running with the template variable `foo` with the value `bar,baz=foo`. This seems unintentional, and this will fix it.

current:
```
$ VAR=foo=bar,baz=foo ./bin/deploy --dry-run --team test
WARNING[2020-01-04T15:56:31.484979+01:00] Config did not pass validation: at least one Kubernetes resource is required to make sense of the deployment
INFO[2020-01-04T15:56:31.485031+01:00] Setting template variable 'foo' to 'bar,baz=foo'
```

fixed:
```
$ VAR=foo=bar,baz=foo ./bin/deploy --dry-run --team test
WARNING[2020-01-04T15:56:06.813223+01:00] Config did not pass validation: at least one Kubernetes resource is required to make sense of the deployment
INFO[2020-01-04T15:56:06.813269+01:00] Setting template variable 'foo' to 'bar'
INFO[2020-01-04T15:56:06.813275+01:00] Setting template variable 'baz' to 'foo'
```