### PR TITLE
feat: customizable GitHub environment parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The final step in the build pipeline triggers the Github Deployments API, where 
 ## How it works
 1. As the final step in one of your CI pipelines, a [deployment request](https://developer.github.com/v3/repos/deployments/#create-a-deployment) is created using GitHub's API. This will trigger a webhook set up at Github.
 2. `hookd` receives the webhook, verifies its integrity and authenticity, and passes the message on to `deployd` via Kafka.
-3. `deployd` receives the message from `hookd`, assumes the identity of the deploying team, and applies your _Kubernetes resources_ into the specified [environment](#environment).
+3. `deployd` receives the message from `hookd`, assumes the identity of the deploying team, and applies your _Kubernetes resources_ into the specified [cluster](https://doc.nais.io/clusters).
 4. If the Kubernetes resources contained any _Application_ or _Deployment_ resources, `deployd` will wait until these are rolled out successfully, or a timeout occurs.
 
 Any fatal error will short-circuit the process with a `error` or `failure` status posted back to Github. A successful deployment will result in a `success` status.
@@ -43,6 +43,7 @@ to track the status of your deployment.
   ],
   "team": "nobody",
   "cluster": "local",
+  "environment": "dev-fss:default",
   "owner": "navikt",
   "repository": "deployment",
   "ref": "master",
@@ -55,6 +56,7 @@ to track the status of your deployment.
 | resources | list[object] | Array of Kubernetes resources |
 | team | string | Team tag |
 | cluster | string | Kubernetes cluster, see [NAIS clusters](https://doc.nais.io/clusters) |
+| environment | string | GitHub environment |
 | owner | string | GitHub repository owner |
 | repository | string | GitHub repository name |
 | ref | string | GitHub commit hash or tag |

--- a/deploy/pkg/deployer/config.go
+++ b/deploy/pkg/deployer/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	APIKey          string
 	DeployServerURL string
 	Cluster         string
+	Environment     string
 	PrintPayload    bool
 	DryRun          bool
 	Owner           string
@@ -38,6 +39,7 @@ func init() {
 	flag.StringVar(&cfg.APIKey, "apikey", os.Getenv("APIKEY"), "NAIS Deploy API key. (env APIKEY)")
 	flag.StringVar(&cfg.DeployServerURL, "deploy-server", getEnv("DEPLOY_SERVER", DefaultDeployServer), "URL to API server. (env DEPLOY_SERVER)")
 	flag.StringVar(&cfg.Cluster, "cluster", os.Getenv("CLUSTER"), "NAIS cluster to deploy into. (env CLUSTER)")
+	flag.StringVar(&cfg.Environment, "environment", os.Getenv("ENVIRONMENT"), "Environment for GitHub deployment. Autodetected from nais.yaml if not specified. (env ENVIRONMENT)")
 	flag.BoolVar(&cfg.DryRun, "dry-run", getEnvBool("DRY_RUN"), "Run templating, but don't actually make any requests. (env DRY_RUN)")
 	flag.StringVar(&cfg.Owner, "owner", getEnv("OWNER", DefaultOwner), "Owner of GitHub repository. (env OWNER)")
 	flag.BoolVar(&cfg.PrintPayload, "print-payload", getEnvBool("PRINT_PAYLOAD"), "Print templated resources to standard output. (env PRINT_PAYLOAD)")

--- a/deploy/pkg/deployer/deployer_test.go
+++ b/deploy/pkg/deployer/deployer_test.go
@@ -27,6 +27,7 @@ func TestHappyPath(t *testing.T) {
 
 		assert.Equal(t, deployRequest.Team, "aura", "auto-detection of team works")
 		assert.Equal(t, deployRequest.Owner, deployer.DefaultOwner, "defaulting works")
+		assert.Equal(t, deployRequest.Environment, "dev-fss:nais", "auto-detection of environment works")
 
 		b, err := json.Marshal(&api_v1_deploy.DeploymentResponse{})
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	cloud.google.com/go/storage v1.1.0
 	github.com/Azure/go-autorest/autorest v0.9.1 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect
-	github.com/DataDog/zstd v1.4.4 // indirect
 	github.com/Shopify/sarama v1.24.1
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/aymerick/raymond v2.0.2+incompatible
@@ -18,7 +17,6 @@ require (
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/go-chi/render v1.0.1
 	github.com/go-ini/ini v1.51.0 // indirect
-	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.3.2
@@ -40,7 +38,6 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
-	github.com/pkg/profile v1.2.1 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/common v0.7.0
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/hookd/pkg/api/v1/deploy/handler.go
+++ b/hookd/pkg/api/v1/deploy/handler.go
@@ -31,13 +31,14 @@ type DeploymentHandler struct {
 }
 
 type DeploymentRequest struct {
-	Resources  json.RawMessage `json:"resources,omitempty"`
-	Team       string          `json:"team,omitempty"`
-	Cluster    string          `json:"cluster,omitempty"`
-	Owner      string          `json:"owner,omitempty"`
-	Repository string          `json:"repository,omitempty"`
-	Ref        string          `json:"ref,omitempty"`
-	Timestamp  int64           `json:"timestamp"`
+	Resources   json.RawMessage `json:"resources,omitempty"`
+	Team        string          `json:"team,omitempty"`
+	Cluster     string          `json:"cluster,omitempty"`
+	Environment string          `json:"environment,omitempty"`
+	Owner       string          `json:"owner,omitempty"`
+	Repository  string          `json:"repository,omitempty"`
+	Ref         string          `json:"ref,omitempty"`
+	Timestamp   int64           `json:"timestamp"`
 }
 
 type DeploymentResponse struct {
@@ -65,6 +66,10 @@ func (r *DeploymentRequest) validate() error {
 		return fmt.Errorf("no cluster specified")
 	}
 
+	if len(r.Environment) == 0 {
+		return fmt.Errorf("no environment specified")
+	}
+
 	if len(r.Team) == 0 {
 		return fmt.Errorf("no team specified")
 	}
@@ -87,7 +92,7 @@ func (r *DeploymentRequest) validate() error {
 func (r *DeploymentRequest) GithubDeploymentRequest() gh.DeploymentRequest {
 	requiredContexts := make([]string, 0)
 	return gh.DeploymentRequest{
-		Environment:      gh.String(r.Cluster),
+		Environment:      gh.String(r.Environment),
 		Ref:              gh.String(r.Ref),
 		Task:             gh.String(api_v1.DirectDeployGithubTask),
 		AutoMerge:        gh.Bool(false),

--- a/hookd/pkg/api/v1/deploy/testdata/apikey_not_found.json
+++ b/hookd/pkg/api/v1/deploy/testdata/apikey_not_found.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/apikey_unavailable.json
+++ b/hookd/pkg/api/v1/deploy/testdata/apikey_unavailable.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/github_unavailable.json
+++ b/hookd/pkg/api/v1/deploy/testdata/github_unavailable.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "unavailable",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/hmac_wrong_encoding.json
+++ b/hookd/pkg/api/v1/deploy/testdata/hmac_wrong_encoding.json
@@ -11,7 +11,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/hmac_wrong_signature.json
+++ b/hookd/pkg/api/v1/deploy/testdata/hmac_wrong_signature.json
@@ -11,7 +11,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_cluster.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_cluster.json
@@ -8,7 +8,8 @@
       "cluster": "not_allowed",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_owner.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_owner.json
@@ -5,7 +5,8 @@
       "team": "nobody",
       "cluster": "local",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_ref.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_ref.json
@@ -5,7 +5,8 @@
       "team": "nobody",
       "cluster": "local",
       "owner": "foo",
-      "repository": "bar"
+      "repository": "bar",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_repository.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_repository.json
@@ -5,7 +5,8 @@
       "team": "nobody",
       "cluster": "local",
       "owner": "foo",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_resources_empty.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_resources_empty.json
@@ -6,7 +6,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/invalid_resources_string.json
+++ b/hookd/pkg/api/v1/deploy/testdata/invalid_resources_string.json
@@ -6,7 +6,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/missing_cluster.json
+++ b/hookd/pkg/api/v1/deploy/testdata/missing_cluster.json
@@ -5,7 +5,8 @@
       "team": "nobody",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/missing_environment.json
+++ b/hookd/pkg/api/v1/deploy/testdata/missing_environment.json
@@ -2,17 +2,17 @@
   "request": {
     "body": {
       "resources": [{}],
-      "cluster": "local",
+      "team": "nobody",
       "owner": "foo",
       "repository": "bar",
       "ref": "master",
-      "environment": "baz"
+      "cluster": "local"
     }
   },
   "response": {
     "statusCode": 400,
     "body": {
-      "message": "invalid deployment request: no team specified"
+      "message": "invalid deployment request: no environment specified"
     }
   }
 }

--- a/hookd/pkg/api/v1/deploy/testdata/team_not_on_github.json
+++ b/hookd/pkg/api/v1/deploy/testdata/team_not_on_github.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/team_not_repo_owner.json
+++ b/hookd/pkg/api/v1/deploy/testdata/team_not_repo_owner.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {

--- a/hookd/pkg/api/v1/deploy/testdata/valid.json
+++ b/hookd/pkg/api/v1/deploy/testdata/valid.json
@@ -8,7 +8,8 @@
       "cluster": "local",
       "owner": "foo",
       "repository": "bar",
-      "ref": "master"
+      "ref": "master",
+      "environment": "baz"
     }
   },
   "response": {


### PR DESCRIPTION
Fixes #54.

Adds support for customizing the `environment` parameter that is sent to the GitHub Deployments API.

If not specified, defaults to auto-detecting the `environment` using the provided `CLUSTER` as well as using the detected namespace from the given resource(s) - e.g. `dev-fss:default`. 
If there are multiple resources in the request with different namespaces, we fall back to using `CLUSTER` as the `environment`. 

Up for discussion: this results in all new deployments with an unspecified environment to have `:$namespace` suffixed, even though a team might just want to use the `default` namespace (or team namespace in GCP) - resulting in `dev-fss:default` instead of `dev-fss`. One could avoid this by not using the namespace suffix for deployments having either:
- namespace matching `default`
- namespace matching `team`

This would maintain the current behavior of environment being equal to the cluster for teams not using any special namespaces. 