### PR TITLE
fix(deployd): ensure correct variables being referenced in goroutine closure

### DIFF
--- a/deployd/pkg/deployd/deployd.go
+++ b/deployd/pkg/deployd/deployd.go
@@ -159,7 +159,7 @@ func Run(logger *log.Entry, req *deployment.DeploymentRequest, cfg config.Config
 
 		logger.Infof("Resource %d: successfully deployed %s", index+1, deployed.GetSelfLink())
 
-		go func() {
+		go func(logger *log.Entry, resource unstructured.Unstructured) {
 			wait.Add(1)
 			logger.Infof("Monitoring rollout status of '%s/%s' in namespace '%s' for %s", gvk, n, ns, deploymentTimeout.String())
 			err := teamClient.WaitForDeployment(logger, resource, time.Now().Add(deploymentTimeout))
@@ -169,7 +169,7 @@ func Run(logger *log.Entry, req *deployment.DeploymentRequest, cfg config.Config
 			}
 			logger.Infof("Finished monitoring rollout status of '%s/%s' in namespace '%s'", gvk, n, ns)
 			wait.Done()
-		}()
+		}(logger, resource)
 	}
 
 	deployStatus <- deployment.NewInProgressStatus(*req)


### PR DESCRIPTION
When deploying with multiple resources, deployd only waits for the last resource as all the goroutines reference the `resource` variable that is overwritten on each iteration due to [how closures work with goroutines](https://golang.org/doc/faq#closures_and_goroutines). 

This results in unexpected behaviour whenever a deployment containing resources that have an implemented watch strategy (e.g. `Application`) are deployed together with a resource that does not (e.g. an `Alert`), resulting in only the `Alert` being watched if it is the last resource to be applied.

The PR fixes this by explicitly declaring new variables for the variables referenced within the goroutine.