### PR TITLE
deployd: relay all Application related cluster events to status database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gophercloud/gophercloud v0.4.0 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jackc/pgx/v4 v4.5.0
-	github.com/nais/liberator v0.0.0-20210125140053-443f810761cb
+	github.com/nais/liberator v0.0.0-20210225122953-48fc806f7cf0
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/pkg/deployd/kubeclient/teamclient.go
+++ b/pkg/deployd/kubeclient/teamclient.go
@@ -1,10 +1,11 @@
 package kubeclient
 
 import (
+	"context"
 	"fmt"
-	"time"
 
 	"github.com/navikt/deployment/pkg/deployd/strategy"
+	"github.com/navikt/deployment/pkg/pb"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -24,7 +25,7 @@ type teamClient struct {
 
 type TeamClient interface {
 	DeployUnstructured(resource unstructured.Unstructured) (*unstructured.Unstructured, error)
-	WaitForDeployment(logger *log.Entry, resource unstructured.Unstructured, deadline time.Time) error
+	WaitForDeployment(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, status chan<- *pb.DeploymentStatus) error
 }
 
 // Implement TeamClient interface
@@ -58,7 +59,7 @@ func (c *teamClient) DeployUnstructured(resource unstructured.Unstructured) (*un
 
 // Returns nil after the next generation of the deployment is successfully rolled out,
 // or error if it has not succeeded within the specified deadline.
-func (c *teamClient) WaitForDeployment(logger *log.Entry, resource unstructured.Unstructured, deadline time.Time) error {
+func (c *teamClient) WaitForDeployment(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, status chan<- *pb.DeploymentStatus) error {
 	gvk := resource.GroupVersionKind()
-	return strategy.NewWatchStrategy(gvk, c.structuredClient, c.unstructuredClient).Watch(logger, resource, deadline)
+	return strategy.NewWatchStrategy(gvk, c.structuredClient, c.unstructuredClient).Watch(ctx, logger, resource, request, status)
 }

--- a/pkg/deployd/strategy/applicationwatch.go
+++ b/pkg/deployd/strategy/applicationwatch.go
@@ -17,18 +17,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	CorrelationIDAnnotation = "nais.io/deploymentCorrelationID"
-)
-
 type application struct {
 	structuredClient   kubernetes.Interface
 	unstructuredClient dynamic.Interface
-}
-
-type appStatus struct {
-	CorrelationID        string
-	SynchronizationState string
 }
 
 func EventString(event *v1.Event) string {
@@ -68,10 +59,7 @@ func EventStreamMatch(event *v1.Event, resourceName string) bool {
 }
 
 func (a application) Watch(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, statusChan chan<- *pb.DeploymentStatus) error {
-	// var updated *unstructured.Unstructured
 	var err error
-	// var status *appStatus
-	// var pickedup bool
 
 	eventsClient := a.structuredClient.CoreV1().Events(resource.GetNamespace())
 	deadline, _ := ctx.Deadline()

--- a/pkg/deployd/strategy/applicationwatch.go
+++ b/pkg/deployd/strategy/applicationwatch.go
@@ -53,7 +53,15 @@ func StatusFromEvent(event *v1.Event, req *pb.DeploymentRequest) *pb.DeploymentS
 }
 
 func EventStreamMatch(event *v1.Event, resourceName string) bool {
-	re := fmt.Sprintf(`^%s(-[a-z0-9]{10}(-[a-z0-9]{5})?)?`, resourceName)
+	var re string
+	switch event.InvolvedObject.Kind {
+	case "Pod":
+		re = fmt.Sprintf(`^%s-[a-z0-9]{10}-[a-z0-9]{5}$`, resourceName)
+	case "ReplicaSet":
+		re = fmt.Sprintf(`^%s-[a-z0-9]{10}$`, resourceName)
+	default:
+		re = fmt.Sprintf(`^%s$`, resourceName)
+	}
 	matched, _ := regexp.MatchString(re, event.InvolvedObject.Name)
 	return matched
 }

--- a/pkg/deployd/strategy/applicationwatch.go
+++ b/pkg/deployd/strategy/applicationwatch.go
@@ -95,7 +95,7 @@ func (a application) getApplicationEvent(resource unstructured.Unstructured, rea
 }
 
 func EventString(event *v1.Event) string {
-	return fmt.Sprintf("%v: %v", event.InvolvedObject.Kind, event.Message)
+	return fmt.Sprintf("%s (%s): %s", event.InvolvedObject.Kind, event.Reason, event.Message)
 }
 
 func StatusFromEvent(event *v1.Event, req *pb.DeploymentRequest) *pb.DeploymentStatus {
@@ -175,7 +175,6 @@ func (a application) Watch(ctx context.Context, logger *log.Entry, resource unst
 				return fmt.Errorf(status.Description)
 			}
 			statusChan <- status
-			logger.Infof("Event: %v", event)
 
 		case <-ctx.Done():
 			return ErrDeploymentTimeout

--- a/pkg/deployd/strategy/jobwatch.go
+++ b/pkg/deployd/strategy/jobwatch.go
@@ -1,9 +1,11 @@
 package strategy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/navikt/deployment/pkg/pb"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,11 +17,12 @@ type job struct {
 	client kubernetes.Interface
 }
 
-func (j job) Watch(logger *log.Entry, resource unstructured.Unstructured, deadline time.Time) error {
+func (j job) Watch(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, status chan<- *pb.DeploymentStatus) error {
 	var job *v1.Job
 	var err error
 
 	client := j.client.BatchV1().Jobs(resource.GetNamespace())
+	deadline, _ := ctx.Deadline()
 
 	// Wait until the new job object is present in the cluster.
 	for deadline.After(time.Now()) {

--- a/pkg/deployd/strategy/watch.go
+++ b/pkg/deployd/strategy/watch.go
@@ -1,9 +1,11 @@
 package strategy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/navikt/deployment/pkg/pb"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -17,13 +19,13 @@ var (
 )
 
 type WatchStrategy interface {
-	Watch(logger *log.Entry, resource unstructured.Unstructured, deadline time.Time) error
+	Watch(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, status chan<- *pb.DeploymentStatus) error
 }
 
 type NoOp struct {
 }
 
-func (c NoOp) Watch(logger *log.Entry, resource unstructured.Unstructured, _ time.Time) error {
+func (c NoOp) Watch(ctx context.Context, logger *log.Entry, resource unstructured.Unstructured, request *pb.DeploymentRequest, status chan<- *pb.DeploymentStatus) error {
 	logger.Infof("Watch not implemented for resource %s/%s", resource.GroupVersionKind().String(), resource.GetName())
 	return nil
 }


### PR DESCRIPTION
This change replaces Application polling with Event watching, listening to all Application related events and relaying them as `in_progress` status updates.