### PR TITLE
feat: sjekk om app eksisterer før create/update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ migration:
 
 kubebuilder:
 	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubebuilder_2.3.1_${os}_${arch}/bin /usr/local/kubebuilder/
+	mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder

--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ migration:
 
 kubebuilder:
 	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+	mv /tmp/kubebuilder_2.3.1_${os}_${arch}/bin /usr/local/kubebuilder/

--- a/pkg/deployd/strategy/deploy.go
+++ b/pkg/deployd/strategy/deploy.go
@@ -39,15 +39,16 @@ func (r recreateStrategy) Deploy(resource unstructured.Unstructured) (*unstructu
 }
 
 func (c createOrUpdateStrategy) Deploy(resource unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	deployed, err := c.client.Create(&resource, metav1.CreateOptions{})
-	if !errors.IsAlreadyExists(err) {
-		return deployed, err
-	}
-
 	existing, err := c.client.Get(resource.GetName(), metav1.GetOptions{})
-	if err != nil {
+	if errors.IsNotFound(err) {
+		deployed, err := c.client.Create(&resource, metav1.CreateOptions{})
+		if err != nil {
+			return deployed, err
+		}
+	} else if err != nil {
 		return nil, fmt.Errorf("get existing resource: %s", err)
 	}
+
 	resource.SetResourceVersion(existing.GetResourceVersion())
 	return c.client.Update(&resource, metav1.UpdateOptions{})
 }

--- a/pkg/deployd/strategy/deploy.go
+++ b/pkg/deployd/strategy/deploy.go
@@ -43,8 +43,9 @@ func (c createOrUpdateStrategy) Deploy(resource unstructured.Unstructured) (*uns
 	if errors.IsNotFound(err) {
 		deployed, err := c.client.Create(&resource, metav1.CreateOptions{})
 		if err != nil {
-			return deployed, err
+			return nil, fmt.Errorf("get existing resource: %s", err)
 		}
+		return deployed, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("get existing resource: %s", err)
 	}


### PR DESCRIPTION
Vi har endret rettigheter i delte namespaces, og man kan ikke lengre opprette application ressurser.

Derfor må vi sjekke om en ressurs eksisterer før vi bestemmer oss for create eller update.