### PR TITLE
Allow passing in pre-pre-provisioned api keys for specific teams

### DIFF
--- a/cmd/hookd/main.go
+++ b/cmd/hookd/main.go
@@ -52,6 +52,7 @@ var maskedConfig = []string{
 
 const (
 	databaseConnectBackoffInterval = 3 * time.Second
+	preProvisionedApiKeysSeparator = ";"
 )
 
 func run() error {
@@ -171,7 +172,7 @@ func run() error {
 
 	if cfg.PreProvisionedApiKeys != nil {
 		for i, entry := range cfg.PreProvisionedApiKeys {
-			parts := strings.Split(entry, ":")
+			parts := strings.Split(entry, preProvisionedApiKeysSeparator)
 			if len(parts) != 3 {
 				log.Errorf("Invalid format for pre-provisioned-api-key, skipping entry %d", i)
 				continue

--- a/pkg/hookd/config/config.go
+++ b/pkg/hookd/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	LogLevel               string        `json:"log-level"`
 	MetricsPath            string        `json:"metrics-path"`
 	ProvisionKey           string        `json:"provision-key"`
+	PreProvisionedApiKeys  []string      `json:"pre-provisioned-api-keys"`
 }
 
 func (a *Azure) HasConfig() bool {
@@ -94,6 +95,7 @@ const (
 	LogLevel                  = "log-level"
 	MetricsPath               = "metrics-path"
 	ProvisionKey              = "provision-key"
+	PreProvisionedApiKeys     = "pre-provisioned-api-keys"
 )
 
 // Bind environment variables provided by the NAIS platform
@@ -154,6 +156,8 @@ func Initialize() *Config {
 	flag.String(AzureWellKnownUrl, "", "URL to Azure configuration.")
 	flag.String(AzureTenant, "", "Azure Tenant")
 	flag.String(AzureTeamMembershipAppId, "", "Application ID of canonical team list")
+
+	flag.StringSlice(PreProvisionedApiKeys, nil, "Pre-shared team API keys, comma separated. Each entry uses the format: team:group_id:key")
 
 	return &Config{}
 }

--- a/pkg/hookd/config/config.go
+++ b/pkg/hookd/config/config.go
@@ -157,7 +157,7 @@ func Initialize() *Config {
 	flag.String(AzureTenant, "", "Azure Tenant")
 	flag.String(AzureTeamMembershipAppId, "", "Application ID of canonical team list")
 
-	flag.StringSlice(PreProvisionedApiKeys, nil, "Pre-shared team API keys, comma separated. Each entry uses the format: team:group_id:key")
+	flag.StringSlice(PreProvisionedApiKeys, nil, "Pre-shared team API keys, comma separated. Each entry uses the format: team;group_id;key")
 
 	return &Config{}
 }


### PR DESCRIPTION
This allows for generating a key outside hookd which can be shared with other systems without user intervention