### PR TITLE
Upgrade actions/checkout@v2 -> v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -45,7 +45,7 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-        queries: security-and-quality 
+        queries: security-and-quality
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
@@ -65,7 +65,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-      
+
     - name: Print SARIF file contents after analysis
       run: |
         for f in $(ls "/home/runner/work/deploy/results"); do

--- a/.github/workflows/job.yaml
+++ b/.github/workflows/job.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy to NAIS
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: deploy to ${{ github.event.inputs.cluster }}
       uses: nais/deploy/actions/deploy@v1
       env:

--- a/.github/workflows/naisjob-without-schedule.yaml
+++ b/.github/workflows/naisjob-without-schedule.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy to NAIS
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: deploy to ${{ github.event.inputs.cluster }}
       uses: nais/deploy/actions/deploy@v1
       env:

--- a/.github/workflows/naisjob.yaml
+++ b/.github/workflows/naisjob.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy to NAIS
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: deploy to ${{ github.event.inputs.cluster }}
       uses: nais/deploy/actions/deploy@v1
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build Docker container
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Generate version tags
       run: |
         echo "version=$(./version.sh)" >> $GITHUB_ENV
@@ -71,7 +71,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Force create tag
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: deploy
     - uses: navikt/github-app-token-generator@v1
@@ -148,7 +148,7 @@ jobs:
         app-id: ${{ secrets.NAIS_APP_ID }}
         repo: navikt/nais-yaml
     - name: Checkout nais-yaml
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: navikt/nais-yaml
         token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/