### PR TITLE
Add internal provision endpoint that returns api keys in response

### DIFF
--- a/pkg/hookd/api/router.go
+++ b/pkg/hookd/api/router.go
@@ -142,5 +142,14 @@ func New(cfg Config) chi.Router {
 		}
 	})
 
+	router.Route("/internal/api/v1", func(r chi.Router) {
+		if len(cfg.ProvisionKey) == 0 {
+			log.Error("Refusing to set up internal team API provisioning endpoint without pre-shared secret; try using --provision-key")
+			log.Error("Note: /internal/api/v1/provision will be unavailable")
+		} else {
+			r.Post("/provision", provisionHandler.ServeInternal)
+		}
+	})
+
 	return router
 }

--- a/pkg/hookd/api/v1/apikey/handler_azure.go
+++ b/pkg/hookd/api/v1/apikey/handler_azure.go
@@ -131,7 +131,7 @@ func (h *AzureApiKeyHandler) RotateTeamApiKey(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	newKey, err := api_v1.Keygen(32)
+	newKey, err := api_v1.Keygen(api_v1.KeySize)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		logger.Errorf("unable to generate new random api key: %s", err)

--- a/pkg/hookd/api/v1/apikey/handler_google.go
+++ b/pkg/hookd/api/v1/apikey/handler_google.go
@@ -141,7 +141,7 @@ func (h *GoogleApiKeyHandler) RotateTeamApiKey(w http.ResponseWriter, r *http.Re
 		keyToRotate = &database.ApiKey{Team: team, GroupId: ""}
 	}
 
-	newKey, err := api_v1.Keygen(32)
+	newKey, err := api_v1.Keygen(api_v1.KeySize)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		logger.Errorf("unable to generate new random api key: %s", err)

--- a/pkg/hookd/api/v1/apikey/handler_test.go
+++ b/pkg/hookd/api/v1/apikey/handler_test.go
@@ -82,7 +82,7 @@ func (a *apiKeyStorage) ApiKeys(ctx context.Context, id string) (database.ApiKey
 	}
 }
 
-func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key []byte) error {
+func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error {
 	switch team {
 	case "team1":
 		return nil

--- a/pkg/hookd/api/v1/keygen.go
+++ b/pkg/hookd/api/v1/keygen.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Generate a cryptographically secure random key of N length.
-func Keygen(length int) ([]byte, error) {
+func Keygen(length int) (Key, error) {
 	buf := make([]byte, length)
 	_, err := rand.Read(buf)
 	return buf, err

--- a/pkg/hookd/api/v1/provision/handler_test.go
+++ b/pkg/hookd/api/v1/provision/handler_test.go
@@ -64,7 +64,7 @@ func (a *apiKeyStorage) ApiKeys(ctx context.Context, team string) (database.ApiK
 	}
 }
 
-func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key []byte) error {
+func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error {
 	switch team {
 	case "unwritable", "unwritable_with_rotate":
 		return fmt.Errorf("service unavailable")

--- a/pkg/hookd/api/v1/teams/handler_test.go
+++ b/pkg/hookd/api/v1/teams/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	api_v1 "github.com/nais/deploy/pkg/hookd/api/v1"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -37,7 +38,7 @@ type response struct {
 	Body       []api_v1_teams.Team `json:"body"`
 }
 
-func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key []byte) error {
+func (a *apiKeyStorage) RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error {
 	return fmt.Errorf("err")
 }
 

--- a/pkg/hookd/database/apikey.go
+++ b/pkg/hookd/database/apikey.go
@@ -21,7 +21,7 @@ type ApiKey struct {
 
 type ApiKeyStore interface {
 	ApiKeys(ctx context.Context, id string) (ApiKeys, error)
-	RotateApiKey(ctx context.Context, team, groupId string, key []byte) error
+	RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error
 }
 
 var _ ApiKeyStore = &Database{}
@@ -99,7 +99,7 @@ func (db *Database) ApiKeys(ctx context.Context, id string) (ApiKeys, error) {
 	return db.scanApiKeyRows(rows)
 }
 
-func (db *Database) RotateApiKey(ctx context.Context, team, groupId string, key []byte) error {
+func (db *Database) RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error {
 	var query string
 
 	encrypted, err := crypto.Encrypt(key, db.encryptionKey)

--- a/pkg/hookd/database/mock_api_key_store.go
+++ b/pkg/hookd/database/mock_api_key_store.go
@@ -4,6 +4,7 @@ package database
 
 import (
 	context "context"
+	api_v1 "github.com/nais/deploy/pkg/hookd/api/v1"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -37,7 +38,7 @@ func (_m *MockApiKeyStore) ApiKeys(ctx context.Context, id string) (ApiKeys, err
 }
 
 // RotateApiKey provides a mock function with given fields: ctx, team, groupId, key
-func (_m *MockApiKeyStore) RotateApiKey(ctx context.Context, team string, groupId string, key []byte) error {
+func (_m *MockApiKeyStore) RotateApiKey(ctx context.Context, team, groupId string, key api_v1.Key) error {
 	ret := _m.Called(ctx, team, groupId, key)
 
 	var r0 error


### PR DESCRIPTION
A secondary provision endpoint rooted elsewhere, which would not be exposed outside the cluster. This will be used by console when running in same cluster, allowing console to get team api keys using the provision key.