### PR TITLE
move kubebuild into the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ RUN apk add --no-cache git make curl
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 
+# this used to live in the makefile, you may want to install kubebuiler manually
+RUN curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz | tar -xz -C /tmp/ && mv /tmp/kubebuilder_2.3.1_linux_amd64 /usr/local/kubebuilder
+
+
 WORKDIR /src
 
 # Copy dependency info
@@ -14,7 +18,6 @@ RUN go mod download
 # Copy rest
 COPY . .
 
-RUN make kubebuilder
 RUN make test
 RUN make alpine
 

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,6 @@ test:
 migration:
 	go generate ./...
 
-kubebuilder:
-	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
-
 check:
 	go run honnef.co/go/tools/cmd/staticcheck ./...
 	go run golang.org/x/vuln/cmd/govulncheck -v ./...


### PR DESCRIPTION
theres more coming on this once I figure out a few things with the deps for kubebuilder: etcd, kubectl, kube-apiserver etc. The goal is to be able to use a newer version (3.9...) of kubebuilder instead of the current one (2.3.1). This is apparently kinda hard.