### PR TITLE
update(canary-deployer): image

### DIFF
--- a/canary-deployer/canary.yml
+++ b/canary-deployer/canary.yml
@@ -16,7 +16,7 @@ spec:
   env:
     - name: DEPLOY_START
       value: "{{ now }}"
-  image: ghcr.io/nais/testapp/testapp:2020-02-25-f61e7b7
+  image: europe-north1-docker.pkg.dev/nais-io/nais/images/testapp:2023.5.11-2cbaba9
   liveness:
     path: /ping
   port: 8080


### PR DESCRIPTION
bør ikke canary bruke den nyere image en noe fra 2020 me eldgamle ting?