### PR TITLE
fix(grpc): retry transient errors when teams service is unavailable

### DIFF
--- a/pkg/grpc/interceptor/auth/server_test.go
+++ b/pkg/grpc/interceptor/auth/server_test.go
@@ -180,8 +180,8 @@ type mockTeamsClient struct {
 	authorized map[string]string
 }
 
-func (m *mockTeamsClient) IsAuthorized(ctx context.Context, repo, team string) bool {
-	return m.authorized[repo] == team
+func (m *mockTeamsClient) IsAuthorized(ctx context.Context, repo, team string) (bool, error) {
+	return m.authorized[repo] == team, nil
 }
 
 func handler(ctx context.Context, req any) (any, error) {

--- a/pkg/naisapi/naisapi.go
+++ b/pkg/naisapi/naisapi.go
@@ -30,15 +30,15 @@ func NewClient(target string, insecureConnection bool) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) IsAuthorized(ctx context.Context, repo, team string) bool {
+func (c *Client) IsAuthorized(ctx context.Context, repo, team string) (bool, error) {
 	resp, err := c.client.IsRepositoryAuthorized(ctx, &protoapi.IsRepositoryAuthorizedRequest{
 		TeamSlug:   team,
 		Repository: repo,
 	})
 	if err != nil {
 		log.WithError(err).Error("checking repo authorization in teams")
-		return false
+		return false, err
 	}
 
-	return resp.IsAuthorized
+	return resp.IsAuthorized, nil
 }


### PR DESCRIPTION
Currently, repository authorization checks returns the PermissionDenied code if the downstream API returned any error response, regardless of actual authorization status.

This change separates errors from the downstream API and the actual authorization state, returning the Unavailable code instead for the former case. This allows for deploy clients to automatically retry transient errors.

Example where a transient error resulted in a misleading error:

- https://github.com/navikt/nks_ds/actions/runs/10177190204/job/28148218534#step:4:20

>  Error: fatal: PermissionDenied: repo "navikt/nks_ds" not authorized by team "nks-aiautomatisering"

and the accompanying error that was logged in hookd:

> {"error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 100.64.161.196:3001: i/o timeout\"","level":"error","msg":"checking repo authorization in teams","time":"2024-07-31T09:00:40.254974821Z"}