### PR TITLE
Allow setting headers on cdn bucket uploads

### DIFF
--- a/actions/cdn-upload/v2/action.yaml
+++ b/actions/cdn-upload/v2/action.yaml
@@ -18,6 +18,9 @@ inputs:
     description: "Keep parent directory name when uploading"
     required: false
     default: "true"
+  headers:
+    description: "Set headers on the uploaded files"
+    required: false
   cache_invalidation:
     description: "Cache invalidation"
     required: false
@@ -114,6 +117,7 @@ runs:
         path: "${{ inputs.source }}"
         parent: '${{ inputs.source_keep_parent_name }}'
         destination: "${{ env.BUCKET_NAME }}/${{ inputs.team }}/${{ inputs.destination }}"
+        headers: "${{ inputs.headers }}"
 
     # Invalidate cache if cache_invalidation is set to true
     - name: "Set up Cloud SDK"


### PR DESCRIPTION
See https://github.com/google-github-actions/upload-cloud-storage?tab=readme-ov-file#user-content-headers

Useful for setting metadata on the uploaded files, like Cache-Control or other headers.
