### PR TITLE
add cache_invalidation to spa-deploy action

### DIFF
--- a/actions/spa-deploy/v2/action.yaml
+++ b/actions/spa-deploy/v2/action.yaml
@@ -1,29 +1,29 @@
-name: "SPA Deploy Action"
-description: "Upload Single Page Application (SPA) to CDN and deploy to NAIS"
+name: 'SPA Deploy Action'
+description: 'Upload Single Page Application (SPA) to CDN and deploy to NAIS'
 inputs:
   team:
-    description: "Team name"
+    description: 'Team name'
     required: true
   app:
-    description: "Application name"
+    description: 'Application name'
     required: true
   source:
-    description: "Application source directory"
+    description: 'Application source directory'
     required: true
   environment:
-    description: "Environment name"
+    description: 'Environment name'
     required: true
   tenant:
-    description: "Tenant slug"
+    description: 'Tenant slug'
     default: "nav"
     required: true
   ingress:
-    description: "Application ingress URL"
+    description: 'Application ingress URL'
     required: true
   ingressClass:
-    description: "Ingress class"
+    description: 'Ingress class'
     required: false
-    default: ""
+    default: ''
   project_id:
     description: "Google Cloud project ID where buckets are hosted"
     required: false

--- a/actions/spa-deploy/v2/action.yaml
+++ b/actions/spa-deploy/v2/action.yaml
@@ -30,6 +30,10 @@ inputs:
   identity_provider:
     description: "Google Workload Identity Provider"
     required: false
+  cache_invalidation:
+    description: "Cache invalidation"
+    required: false
+    default: "false"
 
 outputs:
   url:
@@ -61,6 +65,7 @@ runs:
         destination: ${{ steps.setup.outputs.cdn-destination }}
         project_id: ${{ inputs.project_id }}
         identity_provider: ${{ inputs.identity_provider }}
+        cache_invalidation: ${{ inputs.cache_invalidation == 'true' }}
 
     - id: nais-deploy
       name: Deploy SPA to NAIS

--- a/actions/spa-deploy/v2/action.yaml
+++ b/actions/spa-deploy/v2/action.yaml
@@ -1,29 +1,29 @@
-name: 'SPA Deploy Action'
-description: 'Upload Single Page Application (SPA) to CDN and deploy to NAIS'
+name: "SPA Deploy Action"
+description: "Upload Single Page Application (SPA) to CDN and deploy to NAIS"
 inputs:
   team:
-    description: 'Team name'
+    description: "Team name"
     required: true
   app:
-    description: 'Application name'
+    description: "Application name"
     required: true
   source:
-    description: 'Application source directory'
+    description: "Application source directory"
     required: true
   environment:
-    description: 'Environment name'
+    description: "Environment name"
     required: true
   tenant:
-    description: 'Tenant slug'
+    description: "Tenant slug"
     default: "nav"
     required: true
   ingress:
-    description: 'Application ingress URL'
+    description: "Application ingress URL"
     required: true
   ingressClass:
-    description: 'Ingress class'
+    description: "Ingress class"
     required: false
-    default: ''
+    default: ""
   project_id:
     description: "Google Cloud project ID where buckets are hosted"
     required: false


### PR DESCRIPTION
it forwards the same input to the underlying cdn-upload action that already supports this flag.