### PR TITLE
fix(deployd): force resynchronization of Application and Naisjob

### DIFF
--- a/pkg/deployd/deployd/deployd_test.go
+++ b/pkg/deployd/deployd/deployd_test.go
@@ -40,6 +40,8 @@ type testSpec struct {
 	endStatus         *pb.DeploymentStatus // which end state we expect
 	deployedResources []client.Object      // list of Kubernetes resources expected to be applied to the cluster - only checks name and namespace
 	processing        processCallback      // processing that happens in a coroutine together with deployd.Run(). Requires all resources in `deployedResources` to exist.
+	setup             processCallback      // processing that happens before deployd.Run()
+	verify            func(t *testing.T, ctx context.Context, rig *testRig, test testSpec)
 }
 
 var tests = []testSpec{
@@ -117,7 +119,7 @@ var tests = []testSpec{
 			},
 		},
 		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
-			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.RolloutComplete, "completed", "myapplication"))
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.RolloutComplete, "completed", "Application", "myapplication"))
 		},
 	},
 
@@ -138,7 +140,7 @@ var tests = []testSpec{
 			},
 		},
 		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
-			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.FailedSynchronization, "oops", "myapplication-failedsynchronization"))
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.FailedSynchronization, "oops", "Application", "myapplication-failedsynchronization"))
 		},
 	},
 
@@ -159,7 +161,7 @@ var tests = []testSpec{
 			},
 		},
 		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
-			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.FailedPrepare, "oops", "myapplication-failedprepare"))
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.FailedPrepare, "oops", "Application", "myapplication-failedprepare"))
 		},
 	},
 
@@ -184,6 +186,133 @@ var tests = []testSpec{
 		},
 		deployedResources: nil,
 	},
+
+	// Redeploying an unchanged Application clears the synchronization hash,
+	// so that Naiserator synchronizes it instead of skipping it.
+	{
+		fixture: "testdata/application-resync.json",
+		timeout: 5 * time.Second,
+		endStatus: &pb.DeploymentStatus{
+			State:   pb.DeploymentState_success,
+			Message: "Deployment completed successfully.",
+		},
+		deployedResources: []client.Object{
+			&nais_io_v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myapplication-resync",
+					Namespace: "aura",
+				},
+			},
+		},
+		setup: func(ctx context.Context, rig *testRig, test testSpec) error {
+			app := &nais_io_v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myapplication-resync",
+					Namespace: "aura",
+				},
+				Spec: nais_io_v1alpha1.ApplicationSpec{Image: "foo/bar"},
+			}
+			return createWithStatus(ctx, rig, app, &app.Status)
+		},
+		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.RolloutComplete, "completed", "Application", "myapplication-resync"))
+		},
+		verify: func(t *testing.T, ctx context.Context, rig *testRig, test testSpec) {
+			app := &nais_io_v1alpha1.Application{}
+			err := rig.client.Get(ctx, client.ObjectKey{Name: "myapplication-resync", Namespace: "aura"}, app)
+			assert.NoError(t, err)
+			assertStatusInvalidated(t, app.Status)
+		},
+	},
+
+	// Naisjobs use the same synchronization hash mechanism as Applications.
+	{
+		fixture: "testdata/naisjob-resync.json",
+		timeout: 5 * time.Second,
+		endStatus: &pb.DeploymentStatus{
+			State:   pb.DeploymentState_success,
+			Message: "Deployment completed successfully.",
+		},
+		deployedResources: []client.Object{
+			&nais_io_v1.Naisjob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mynaisjob-resync",
+					Namespace: "aura",
+				},
+			},
+		},
+		setup: func(ctx context.Context, rig *testRig, test testSpec) error {
+			job := &nais_io_v1.Naisjob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mynaisjob-resync",
+					Namespace: "aura",
+				},
+				Spec: nais_io_v1.NaisjobSpec{Image: "foo/bar", Schedule: "*/1 * * * *"},
+			}
+			return createWithStatus(ctx, rig, job, &job.Status)
+		},
+		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.RolloutComplete, "completed", "Naisjob", "mynaisjob-resync"))
+		},
+		verify: func(t *testing.T, ctx context.Context, rig *testRig, test testSpec) {
+			job := &nais_io_v1.Naisjob{}
+			err := rig.client.Get(ctx, client.ObjectKey{Name: "mynaisjob-resync", Namespace: "aura"}, job)
+			assert.NoError(t, err)
+			assertStatusInvalidated(t, job.Status)
+		},
+	},
+
+	// Naiserator's no-op rollout event describes the state before the forced
+	// resynchronization. Accepting it would report success without observing the
+	// rollout, so the deploy must keep waiting and time out when nothing follows.
+	{
+		fixture: "testdata/application-noop.json",
+		timeout: 3 * time.Second,
+		endStatus: &pb.DeploymentStatus{
+			State:   pb.DeploymentState_failure,
+			Message: "timeout while waiting for deployment to succeed (total of 1 errors)",
+		},
+		deployedResources: []client.Object{
+			&nais_io_v1alpha1.Application{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "myapplication-noop",
+					Namespace: "aura",
+				},
+			},
+		},
+		processing: func(ctx context.Context, rig *testRig, test testSpec) error {
+			return rig.client.Create(ctx, naiseratorEvent(test.fixture, events.RolloutComplete, rolloutMessageNoop, "Application", "myapplication-noop"))
+		},
+	},
+}
+
+// rolloutMessageNoop mirrors Naiserator's RolloutMessageNoop.
+const rolloutMessageNoop = "No changes; deployment already up to date"
+
+// createWithStatus persists a workload along with the status Naiserator would have
+// written after a successful deployment. Status is a subresource, so it needs a
+// separate write.
+func createWithStatus(ctx context.Context, rig *testRig, resource client.Object, status *nais_io_v1.Status) error {
+	err := rig.client.Create(ctx, resource)
+	if err != nil {
+		return err
+	}
+
+	*status = nais_io_v1.Status{
+		SynchronizationHash:  "synchronized-hash",
+		SynchronizationState: events.RolloutComplete,
+		CorrelationID:        "previous-deployment",
+	}
+
+	return rig.client.Status().Update(ctx, resource)
+}
+
+// assertStatusInvalidated checks that only the synchronization hash was cleared, so
+// that Naiserator resynchronizes without losing the rest of its status.
+func assertStatusInvalidated(t *testing.T, status nais_io_v1.Status) {
+	assert.Empty(t, status.SynchronizationHash)
+	assert.Equal(t, events.RolloutComplete, status.SynchronizationState)
+	assert.Equal(t, "previous-deployment", status.CorrelationID)
 }
 
 type testRig struct {
@@ -460,6 +589,14 @@ func subTest(t *testing.T, rig *testRig, test testSpec, team string) {
 		panic(fmt.Sprintf("test data fixture error in '%s': %s", test.fixture, err))
 	}
 
+	if test.setup != nil {
+		err = test.setup(ctx, rig, test)
+		if err != nil {
+			t.Errorf("Set up fixture: %s", err)
+			t.FailNow()
+		}
+	}
+
 	opctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -507,9 +644,13 @@ func subTest(t *testing.T, rig *testRig, test testSpec, team string) {
 	assert.NoError(t, err)
 
 	wg.Wait()
+
+	if test.verify != nil {
+		test.verify(t, ctx, rig, test)
+	}
 }
 
-func naiseratorEvent(id, reason, message, app string) *v1.Event {
+func naiseratorEvent(id, reason, message, kind, name string) *v1.Event {
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "event-" + keygen.RandStringBytes(10),
@@ -522,9 +663,9 @@ func naiseratorEvent(id, reason, message, app string) *v1.Event {
 		Reason:              reason,
 		Message:             message,
 		InvolvedObject: v1.ObjectReference{
-			Kind:      "Application",
+			Kind:      kind,
 			Namespace: "aura",
-			Name:      app,
+			Name:      name,
 		},
 		LastTimestamp: metav1.NewTime(time.Now()),
 	}

--- a/pkg/deployd/deployd/testdata/application-noop.json
+++ b/pkg/deployd/deployd/testdata/application-noop.json
@@ -1,0 +1,13 @@
+[
+  {
+    "kind": "Application",
+    "apiVersion": "nais.io/v1alpha1",
+    "metadata": {
+      "name": "myapplication-noop",
+      "namespace": "aura"
+    },
+    "spec": {
+      "image": "foo/bar"
+    }
+  }
+]

--- a/pkg/deployd/deployd/testdata/application-resync.json
+++ b/pkg/deployd/deployd/testdata/application-resync.json
@@ -1,0 +1,13 @@
+[
+  {
+    "kind": "Application",
+    "apiVersion": "nais.io/v1alpha1",
+    "metadata": {
+      "name": "myapplication-resync",
+      "namespace": "aura"
+    },
+    "spec": {
+      "image": "foo/bar"
+    }
+  }
+]

--- a/pkg/deployd/deployd/testdata/naisjob-resync.json
+++ b/pkg/deployd/deployd/testdata/naisjob-resync.json
@@ -1,0 +1,14 @@
+[
+  {
+    "kind": "Naisjob",
+    "apiVersion": "nais.io/v1",
+    "metadata": {
+      "name": "mynaisjob-resync",
+      "namespace": "aura"
+    },
+    "spec": {
+      "image": "foo/bar",
+      "schedule": "*/1 * * * *"
+    }
+  }
+]

--- a/pkg/deployd/strategy/deploy.go
+++ b/pkg/deployd/strategy/deploy.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -46,7 +47,33 @@ func (c createOrUpdateStrategy) Deploy(ctx context.Context, resource unstructure
 		return nil, fmt.Errorf("updating resource: %w", transformStrictDecodingError(resource, err))
 	}
 
+	if shouldInvalidateSynchronizationHash(resource) {
+		err = c.invalidateSynchronizationHash(ctx, resource.GetName())
+		if err != nil {
+			return nil, fmt.Errorf("invalidating synchronization hash: %w", err)
+		}
+		trace.AddEvent("Forced resynchronization of Nais resource")
+	}
+
 	return updated, nil
+}
+
+func shouldInvalidateSynchronizationHash(resource unstructured.Unstructured) bool {
+	gvk := resource.GroupVersionKind()
+	return gvk.Group == "nais.io" && (gvk.Kind == "Application" || gvk.Kind == "Naisjob")
+}
+
+// invalidateSynchronizationHash clears the hash Naiserator compares against to decide
+// whether a resource needs synchronization. Without this, redeploying an unchanged spec
+// is a no-op, and the deployment waits for a rollout event that never arrives.
+//
+// The resource spec is written before this call, so the resynchronization picks up the
+// spec and correlation ID from this deployment. Only the hash field is patched, leaving
+// the rest of the operator-owned status untouched.
+func (c createOrUpdateStrategy) invalidateSynchronizationHash(ctx context.Context, name string) error {
+	_, err := c.client.Patch(ctx, name, types.MergePatchType,
+		[]byte(`{"status":{"synchronizationHash":null}}`), metav1.PatchOptions{}, "status")
+	return err
 }
 
 func transformStrictDecodingError(resource unstructured.Unstructured, err error) error {

--- a/pkg/deployd/strategy/deploy_test.go
+++ b/pkg/deployd/strategy/deploy_test.go
@@ -1,0 +1,145 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var (
+	applicationGVK = schema.GroupVersionKind{Group: "nais.io", Version: "v1alpha1", Kind: "Application"}
+	applicationGVR = schema.GroupVersionResource{Group: "nais.io", Version: "v1alpha1", Resource: "applications"}
+	naisjobGVK     = schema.GroupVersionKind{Group: "nais.io", Version: "v1", Kind: "Naisjob"}
+	naisjobGVR     = schema.GroupVersionResource{Group: "nais.io", Version: "v1", Resource: "naisjobs"}
+)
+
+// Redeploying an unchanged spec must still trigger Naiserator, which only synchronizes
+// when its stored hash differs from the hash it computes.
+func TestDeployInvalidatesSynchronizationHash(t *testing.T) {
+	tests := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		gvr  schema.GroupVersionResource
+	}{
+		{name: "Application", gvk: applicationGVK, gvr: applicationGVR},
+		{name: "Naisjob", gvk: naisjobGVK, gvr: naisjobGVR},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := testResource(tt.gvk)
+			require.NoError(t, unstructured.SetNestedField(existing.Object, "current-hash", "status", "synchronizationHash"))
+			desired := existing.DeepCopy()
+
+			client := fake.NewSimpleDynamicClient(runtime.NewScheme(), &existing)
+			resourceClient := client.Resource(tt.gvr).Namespace(existing.GetNamespace())
+
+			deployed, err := NewDeployStrategy(resourceClient).Deploy(t.Context(), *desired, noop.Span{})
+			require.NoError(t, err)
+			require.NotNil(t, deployed)
+
+			// The spec must be written before the hash is cleared, so that the
+			// resynchronization picks up this deployment rather than the previous one.
+			require.Equal(t, []string{"get", "update", "patch"}, verbs(client.Actions()))
+
+			patch := lastPatch(t, client.Actions())
+			require.Equal(t, "status", patch.GetSubresource())
+			require.Equal(t, types.MergePatchType, patch.GetPatchType())
+			require.JSONEq(t, `{"status":{"synchronizationHash":null}}`, string(patch.GetPatch()))
+		})
+	}
+}
+
+func TestDeployDoesNotInvalidateSynchronizationHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		gvk      schema.GroupVersionKind
+		gvr      schema.GroupVersionResource
+		existing bool
+	}{
+		{
+			name: "new Application is synchronized on creation",
+			gvk:  applicationGVK,
+			gvr:  applicationGVR,
+		},
+		{
+			name:     "ConfigMap has no synchronization hash",
+			gvk:      schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"},
+			gvr:      schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
+			existing: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := testResource(tt.gvk)
+			client := fake.NewSimpleDynamicClient(runtime.NewScheme())
+			resourceClient := client.Resource(tt.gvr).Namespace(resource.GetNamespace())
+			if tt.existing {
+				_, err := resourceClient.Create(t.Context(), &resource, metav1.CreateOptions{})
+				require.NoError(t, err)
+				client.ClearActions()
+			}
+
+			_, err := NewDeployStrategy(resourceClient).Deploy(t.Context(), resource, noop.Span{})
+			require.NoError(t, err)
+			require.NotContains(t, verbs(client.Actions()), "patch")
+		})
+	}
+}
+
+// A resource whose hash was not cleared silently stops reconciling, so the deployment
+// must fail loudly rather than wait for a rollout that never happens.
+func TestDeployFailsWhenSynchronizationHashCannotBeInvalidated(t *testing.T) {
+	existing := testResource(applicationGVK)
+	desired := existing.DeepCopy()
+
+	client := fake.NewSimpleDynamicClient(runtime.NewScheme(), &existing)
+	client.PrependReactor("patch", "applications", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewForbidden(applicationGVR.GroupResource(), existing.GetName(), nil)
+	})
+	resourceClient := client.Resource(applicationGVR).Namespace(existing.GetNamespace())
+
+	_, err := NewDeployStrategy(resourceClient).Deploy(t.Context(), *desired, noop.Span{})
+	require.ErrorContains(t, err, "invalidating synchronization hash")
+	require.True(t, errors.IsForbidden(err))
+}
+
+func verbs(actions []k8stesting.Action) []string {
+	found := make([]string, 0, len(actions))
+	for _, action := range actions {
+		found = append(found, action.GetVerb())
+	}
+	return found
+}
+
+func lastPatch(t *testing.T, actions []k8stesting.Action) k8stesting.PatchAction {
+	t.Helper()
+	for i := len(actions) - 1; i >= 0; i-- {
+		if patch, ok := actions[i].(k8stesting.PatchAction); ok {
+			return patch
+		}
+	}
+	t.Fatal("expected a patch action")
+	return nil
+}
+
+func testResource(gvk schema.GroupVersionKind) unstructured.Unstructured {
+	resource := unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":      "test-resource",
+			"namespace": "test-namespace",
+		},
+	}}
+	resource.SetGroupVersionKind(gvk)
+	return resource
+}

--- a/pkg/deployd/strategy/nais.go
+++ b/pkg/deployd/strategy/nais.go
@@ -23,6 +23,12 @@ type naisResource struct {
 	client kubeclient.Interface
 }
 
+// rolloutMessageNoop mirrors Naiserator's RolloutMessageNoop, which it emits when a
+// redeploy has no spec changes. deployd forces a resynchronization on every deploy, so
+// this message describes the state before that resynchronization and must not finish
+// the wait. The real rollout event follows.
+const rolloutMessageNoop = "No changes; deployment already up to date"
+
 func (a naisResource) Watch(op *operation.Operation, resource unstructured.Unstructured, trace trace.Span) *pb.DeploymentStatus {
 	var err error
 
@@ -70,6 +76,11 @@ func (a naisResource) Watch(op *operation.Operation, resource unstructured.Unstr
 
 			if event.LastTimestamp.Time.Before(watchStart) {
 				op.Logger.Tracef("Ignoring old event %s", event.Name)
+				continue
+			}
+
+			if event.Message == rolloutMessageNoop {
+				op.Logger.Tracef("Ignoring no-op rollout event %s; awaiting forced resynchronization", event.Name)
 				continue
 			}
 


### PR DESCRIPTION
## Problem

Redeploying an `Application` or `Naisjob` with an unchanged spec hangs until timeout.

## Cause

Both kinds gained a status subresource in liberator
[bacd0593](https://github.com/nais/liberator/commit/bacd0593). Before that, deployd's
update wiped `.status` as a side effect, so Naiserator always saw a hash mismatch and
synchronized. Now `.status` survives, the hash matches, and Naiserator skips
synchronization without emitting an event.

Naiserator's own mitigation in
[786b92a8](https://github.com/nais/naiserator/commit/786b92a8) only covers workloads in
`RolloutComplete`, and reports completion without actually resynchronizing.

## Solution

Clear `status.synchronizationHash` via the status subresource after writing the spec, so
a deploy always resynchronizes. Only that field is patched.

This also unblocks workloads stuck in `FailedSynchronization`, which persist their hash
and otherwise never reconcile again without a spec change.

Naiserator's no-op rollout event is ignored while waiting, since it describes the state
before the forced resynchronization.